### PR TITLE
feat: add telegram setup

### DIFF
--- a/.github/templates/deploy-container/action.yml
+++ b/.github/templates/deploy-container/action.yml
@@ -66,6 +66,10 @@ inputs:
 
   swagger-password:
     required: true
+  telegram-uptime-bot-token:
+    required: true
+  telegram-uptime-bot-secret:
+    required: true
 
 runs:
   using: 'composite'
@@ -105,4 +109,6 @@ runs:
           -e CLICKHOUSE_PASSWORD=${{ inputs.clickhouse-password }} \
           -e CLICKHOUSE_DATABASE=${{ inputs.clickhouse-database }} \
           -e SWAGGER_PASSWORD=${{ inputs.swagger-password }} \
+          -e TELEGRAM_UPTIME_BOT_TOKEN=${{ inputs.telegram-uptime-bot-token }} \
+          -e TELEGRAM_UPTIME_BOT_SECRET=${{ inputs.telegram-uptime-bot-secret }} \
           ${{ inputs.image-name }}

--- a/.github/templates/test/action.yml
+++ b/.github/templates/test/action.yml
@@ -18,3 +18,5 @@ runs:
       env:
         OUR_ENV: 'dev'
         AUTH_JWT_SECRET: 'test'
+        TELEGRAM_UPTIME_BOT_TOKEN: 'token'
+        TELEGRAM_UPTIME_BOT_SECRET: 'secret'

--- a/.github/workflows/backend-dev-deploy.yml
+++ b/.github/workflows/backend-dev-deploy.yml
@@ -62,6 +62,8 @@ jobs:
           clickhouse-password: ${{ secrets.BACKEND_DEV_CLICKHOUSE_PASSWORD }}
           clickhouse-database: default
           swagger-password: ${{ secrets.BACKEND_SWAGGER_PASSWORD }}
+          telegram-uptime-bot-token: ${{ secrets.BACKEND_DEV_TELEGRAM_UPTIME_BOT_TOKEN }}
+          telegram-uptime-bot-secret: ${{ secrets.BACKEND_DEV_TELEGRAM_UPTIME_BOT_SECRET }}
       - name: Prune
         uses: './.github/templates/prune'
         with:

--- a/.github/workflows/backend-local-deploy.yml
+++ b/.github/workflows/backend-local-deploy.yml
@@ -54,3 +54,5 @@ jobs:
           clickhouse-password: ${{ secrets.BACKEND_LOCAL_CLICKHOUSE_PASSWORD }}
           clickhouse-database: default
           swagger-password: ${{ secrets.BACKEND_SWAGGER_PASSWORD }}
+          telegram-uptime-bot-token: ${{ secrets.BACKEND_LOCAL_TELEGRAM_UPTIME_BOT_TOKEN }}
+          telegram-uptime-bot-secret: ${{ secrets.BACKEND_LOCAL_TELEGRAM_UPTIME_BOT_SECRET }}

--- a/.github/workflows/backend-prod-deploy.yml
+++ b/.github/workflows/backend-prod-deploy.yml
@@ -63,6 +63,8 @@ jobs:
           clickhouse-password: ${{ secrets.BACKEND_PROD_CLICKHOUSE_PASSWORD }}
           clickhouse-database: default
           swagger-password: ${{ secrets.BACKEND_SWAGGER_PASSWORD }}
+          telegram-uptime-bot-token: ${{ secrets.BACKEND_PROD_TELEGRAM_UPTIME_BOT_TOKEN }}
+          telegram-uptime-bot-secret: ${{ secrets.BACKEND_PROD_TELEGRAM_UPTIME_BOT_SECRET }}
       - name: Prune
         uses: './.github/templates/prune'
         with:

--- a/apps/backend/src/notification-channel/core/notification-channel-core.module.ts
+++ b/apps/backend/src/notification-channel/core/notification-channel-core.module.ts
@@ -4,16 +4,19 @@ import { NotificationChannelWriteModule } from '../write/notification-channel-wr
 import { NotificationChannelCoreController } from './notification-channel-core.controller';
 import { NotificationChannelMessagingModule } from '../messaging/notification-channel-messaging.module';
 import { ClusterMemberGuardImports } from '../../cluster/guards/cluster-member/cluster-member.guard';
+import { TelegramSetupModule } from '../setup/telegram/telegram-setup.module';
+import { NotificationChannelOptionsEnrichmentService } from './notification-channel-options-enrichment.service';
 
 @Module({
   imports: [
     NotificationChannelReadModule,
     NotificationChannelWriteModule,
     NotificationChannelMessagingModule,
+    TelegramSetupModule,
     ...ClusterMemberGuardImports,
   ],
   controllers: [NotificationChannelCoreController],
-  providers: [],
+  providers: [NotificationChannelOptionsEnrichmentService],
   exports: [],
 })
 export class NotificationChannelCoreModule {}

--- a/apps/backend/src/notification-channel/core/notification-channel-options-enrichment.service.ts
+++ b/apps/backend/src/notification-channel/core/notification-channel-options-enrichment.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { NotificationChannelWriteService } from '../write/notification-channel-write.service';
+import { NotificationChannelOptions } from './entities/notification-channel.entity';
+import { TelegramOptions } from './types/telegram-options.type';
+import { NotificationTarget } from './enums/notification-target.enum';
+import { getEnvConfig } from '../../shared/configs/env-configs';
+
+@Injectable()
+export class NotificationChannelOptionsEnrichmentService {
+  constructor() {}
+
+  public async enrichOptions(
+    options: NotificationChannelOptions,
+    target: NotificationTarget,
+  ): Promise<NotificationChannelOptions> {
+    if (target === NotificationTarget.Telegram) {
+      return this.enrichTelegramOptions(options as TelegramOptions);
+    }
+
+    return options;
+  }
+
+  private async enrichTelegramOptions(options: TelegramOptions): Promise<TelegramOptions> {
+    if (!options.botToken) {
+      options.botToken = getEnvConfig().notificationChannels.telegramUptimeBot.token;
+    }
+
+    return options;
+  }
+}

--- a/apps/backend/src/notification-channel/core/notification-channel-options-enrichment.service.ts
+++ b/apps/backend/src/notification-channel/core/notification-channel-options-enrichment.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@nestjs/common';
-import { NotificationChannelWriteService } from '../write/notification-channel-write.service';
 import { NotificationChannelOptions } from './entities/notification-channel.entity';
 import { TelegramOptions } from './types/telegram-options.type';
 import { NotificationTarget } from './enums/notification-target.enum';
@@ -13,11 +12,13 @@ export class NotificationChannelOptionsEnrichmentService {
     options: NotificationChannelOptions,
     target: NotificationTarget,
   ): Promise<NotificationChannelOptions> {
+    const optionsDeepCopy = structuredClone(options);
+
     if (target === NotificationTarget.Telegram) {
-      return this.enrichTelegramOptions(options as TelegramOptions);
+      return this.enrichTelegramOptions(optionsDeepCopy as TelegramOptions);
     }
 
-    return options;
+    return optionsDeepCopy;
   }
 
   private async enrichTelegramOptions(options: TelegramOptions): Promise<TelegramOptions> {

--- a/apps/backend/src/notification-channel/core/types/telegram-options.type.ts
+++ b/apps/backend/src/notification-channel/core/types/telegram-options.type.ts
@@ -1,10 +1,13 @@
-import { ApiExtraModels, ApiProperty } from '@nestjs/swagger';
-import { IsString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
 
 export class TelegramOptionsValidator {
-  @ApiProperty()
+  @ApiPropertyOptional({
+    description: 'If not provided, will use default logdash uptime bot token',
+  })
+  @IsOptional()
   @IsString()
-  public botToken: string;
+  public botToken?: string;
 
   @ApiProperty()
   @IsString()
@@ -12,6 +15,6 @@ export class TelegramOptionsValidator {
 }
 
 export interface TelegramOptions {
-  botToken: string;
+  botToken?: string;
   chatId: string;
 }

--- a/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.dto.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.dto.ts
@@ -1,0 +1,4 @@
+export interface TelegramChatInfo {
+  id: string;
+  name: string;
+}

--- a/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.query.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.query.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class TelegramChatInfoQuery {
+  @ApiProperty()
+  @IsString()
+  public passphrase: string;
+}

--- a/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.response.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/dto/telegram-chat-info.response.ts
@@ -1,0 +1,12 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class TelegramChatInfoResponse {
+  @ApiProperty()
+  public success: boolean;
+
+  @ApiPropertyOptional()
+  public chatId?: string;
+
+  @ApiPropertyOptional()
+  public name?: string;
+}

--- a/apps/backend/src/notification-channel/setup/telegram/dto/telegram-update.dto.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/dto/telegram-update.dto.ts
@@ -1,0 +1,23 @@
+export interface TelegramUpdateDto {
+  update_id: number;
+  message?: {
+    message_id: number;
+    from: {
+      id: number;
+      is_bot: boolean;
+      first_name: string;
+      last_name?: string;
+      username?: string;
+    };
+    chat: {
+      id: number;
+      type: string;
+      title?: string;
+      username?: string;
+      first_name?: string;
+      last_name?: string;
+    };
+    date: number;
+    text?: string;
+  };
+}

--- a/apps/backend/src/notification-channel/setup/telegram/telegram-setup.controller.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/telegram-setup.controller.ts
@@ -1,0 +1,36 @@
+import { Body, Controller, Get, Headers, Post, Query } from '@nestjs/common';
+import { ApiResponse, ApiTags } from '@nestjs/swagger';
+import { TelegramSetupService } from './telegram-setup.service';
+import { TelegramChatInfoQuery } from './dto/telegram-chat-info.query';
+import { TelegramChatInfoResponse } from './dto/telegram-chat-info.response';
+import { Public } from '../../../auth/core/decorators/is-public';
+import { TelegramUpdateDto } from './dto/telegram-update.dto';
+
+@ApiTags('Notification channel setup (telegram)')
+@Controller('notification_channel_setup/telegram')
+export class TelegramSetupController {
+  constructor(private readonly telegramApiService: TelegramSetupService) {}
+
+  @Get('chat_info')
+  @ApiResponse({ type: TelegramChatInfoResponse })
+  public async fetchChats(
+    @Query() query: TelegramChatInfoQuery,
+  ): Promise<TelegramChatInfoResponse> {
+    const chatInfo = await this.telegramApiService.getChatInfoForPassphrase(query.passphrase);
+
+    if (!chatInfo) {
+      return { success: false };
+    }
+
+    return { success: true, chatId: chatInfo.id, name: chatInfo.name };
+  }
+
+  @Public()
+  @Post('bot_webhook')
+  public async webhookUpdate(
+    @Body() body: TelegramUpdateDto,
+    @Headers('X-Telegram-Bot-Api-Secret-Token') secret: string,
+  ) {
+    await this.telegramApiService.webhookUpdate(body, secret);
+  }
+}

--- a/apps/backend/src/notification-channel/setup/telegram/telegram-setup.module.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/telegram-setup.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TelegramSetupController } from './telegram-setup.controller';
+import { TelegramSetupService } from './telegram-setup.service';
+
+@Module({
+  controllers: [TelegramSetupController],
+  providers: [TelegramSetupService],
+})
+export class TelegramSetupModule {}

--- a/apps/backend/src/notification-channel/setup/telegram/telegram-setup.service.ts
+++ b/apps/backend/src/notification-channel/setup/telegram/telegram-setup.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { RedisService } from '../../../shared/redis/redis.service';
+import { getEnvConfig } from '../../../shared/configs/env-configs';
+import { TelegramChatInfo } from './dto/telegram-chat-info.dto';
+import { TelegramUpdateDto } from './dto/telegram-update.dto';
+
+const PASSPHRASE_BIND_TTL_SECONDS = 60;
+
+@Injectable()
+export class TelegramSetupService {
+  constructor(private readonly redisService: RedisService) {}
+
+  public async getChatInfoForPassphrase(passphrase: string): Promise<TelegramChatInfo | null> {
+    const redisKey = await this.getRedisKeyForPassphrase(passphrase);
+
+    const chatInfo = await this.redisService.get(redisKey);
+
+    if (!chatInfo) {
+      return null;
+    }
+
+    return JSON.parse(chatInfo);
+  }
+
+  public async webhookUpdate(update: TelegramUpdateDto, secret: string): Promise<void> {
+    const expectedSecret = getEnvConfig().notificationChannels.telegramUptimeBot.secret;
+
+    if (
+      !update.message ||
+      secret !== expectedSecret ||
+      !update.message.text ||
+      !update.message.text.startsWith('/')
+    ) {
+      return;
+    }
+
+    const chatInfo: TelegramChatInfo = {
+      id: update.message.chat.id.toString(),
+      name: await this.getChatNameFromUpdate(update),
+    };
+
+    const redisKey = await this.getRedisKeyForPassphrase(update.message.text);
+
+    await this.redisService.set(redisKey, JSON.stringify(chatInfo), PASSPHRASE_BIND_TTL_SECONDS);
+  }
+
+  private async getChatNameFromUpdate(update: TelegramUpdateDto): Promise<string> {
+    if (update.message?.chat.title) {
+      return update.message.chat.title;
+    }
+
+    if (update.message?.chat.last_name && update.message?.chat.first_name) {
+      return `${update.message.chat.first_name} ${update.message.chat.last_name}`;
+    }
+
+    if (update.message?.chat.first_name) {
+      return update.message.chat.first_name;
+    }
+
+    if (update.message?.chat.username) {
+      return update.message.chat.username;
+    }
+
+    return '';
+  }
+
+  private async getRedisKeyForPassphrase(passphrase: string): Promise<string> {
+    return `notification-channel-setup:telegram:${passphrase}`;
+  }
+}

--- a/apps/backend/src/shared/configs/env-configs.ts
+++ b/apps/backend/src/shared/configs/env-configs.ts
@@ -69,6 +69,12 @@ interface EnvConfig {
     password: string;
     database: string;
   };
+  notificationChannels: {
+    telegramUptimeBot: {
+      secret: string;
+      token: string;
+    };
+  };
 }
 
 interface EnvConfigs {
@@ -147,6 +153,12 @@ export const EnvConfigs: EnvConfigs = {
       password: process.env.CLICKHOUSE_PASSWORD!,
       database: process.env.CLICKHOUSE_DATABASE!,
     },
+    notificationChannels: {
+      telegramUptimeBot: {
+        secret: process.env.TELEGRAM_UPTIME_BOT_SECRET!,
+        token: process.env.TELEGRAM_UPTIME_BOT_TOKEN!,
+      },
+    },
   },
   [OurEnv.Dev]: {
     emailLoginWhitelist: {
@@ -217,6 +229,12 @@ export const EnvConfigs: EnvConfigs = {
       password: process.env.CLICKHOUSE_PASSWORD!,
       database: process.env.CLICKHOUSE_DATABASE!,
     },
+    notificationChannels: {
+      telegramUptimeBot: {
+        secret: process.env.TELEGRAM_UPTIME_BOT_SECRET!,
+        token: process.env.TELEGRAM_UPTIME_BOT_TOKEN!,
+      },
+    },
   },
   [OurEnv.Local]: {
     emailLoginWhitelist: {
@@ -286,6 +304,12 @@ export const EnvConfigs: EnvConfigs = {
       username: process.env.CLICKHOUSE_USER!,
       password: process.env.CLICKHOUSE_PASSWORD!,
       database: process.env.CLICKHOUSE_DATABASE!,
+    },
+    notificationChannels: {
+      telegramUptimeBot: {
+        secret: process.env.TELEGRAM_UPTIME_BOT_SECRET!,
+        token: process.env.TELEGRAM_UPTIME_BOT_TOKEN!,
+      },
     },
   },
 };

--- a/apps/backend/test/http-monitors/full-process.spec.ts
+++ b/apps/backend/test/http-monitors/full-process.spec.ts
@@ -39,7 +39,7 @@ describe('Http monitor full process', () => {
 
     let telegramPostedDtos: any[] = [];
     await bootstrap.utils.telegramUtils.setUpTelegramSendMessageListener({
-      botId: (channel.options as TelegramOptions).botToken,
+      botId: (channel.options as TelegramOptions).botToken!,
       onMessage: (dto) => {
         telegramPostedDtos.push(dto);
       },

--- a/apps/backend/test/notification-channel/providers/telegram.spec.ts
+++ b/apps/backend/test/notification-channel/providers/telegram.spec.ts
@@ -31,7 +31,7 @@ describe('Telegram communication channel', () => {
     const requestBodies: any[] = [];
 
     bootstrap.utils.telegramUtils.setUpTelegramSendMessageListener({
-      botId: (channel.options as TelegramOptions).botToken,
+      botId: (channel.options as TelegramOptions).botToken!,
       onMessage: (body) => {
         requestBodies.push(body);
       },

--- a/apps/backend/test/notification-channel/setup/telegram.spec.ts
+++ b/apps/backend/test/notification-channel/setup/telegram.spec.ts
@@ -1,0 +1,201 @@
+import * as request from 'supertest';
+import { createTestApp } from '../../utils/bootstrap';
+import { getEnvConfig } from '../../../src/shared/configs/env-configs';
+import { TelegramUpdateDto } from '../../../src/notification-channel/setup/telegram/dto/telegram-update.dto';
+
+describe('TelegramSetupController', () => {
+  let bootstrap: Awaited<ReturnType<typeof createTestApp>>;
+
+  beforeAll(async () => {
+    bootstrap = await createTestApp();
+  });
+
+  beforeEach(async () => {
+    await bootstrap.methods.beforeEach();
+  });
+
+  afterAll(async () => {
+    await bootstrap.methods.afterAll();
+  });
+
+  const validTelegramSecret = getEnvConfig().notificationChannels.telegramUptimeBot.secret;
+
+  it('gets private chat info', async () => {
+    const { token } = await bootstrap.utils.generalUtils.setupAnonymous();
+
+    // given
+    const telegramUpdate: TelegramUpdateDto = {
+      update_id: 123456,
+      message: {
+        message_id: 1,
+        from: {
+          id: 987654321,
+          is_bot: false,
+          first_name: 'John',
+          last_name: 'Doe',
+          username: 'johndoe',
+        },
+        chat: {
+          id: 123456789,
+          type: 'private',
+          first_name: 'John',
+          last_name: 'Doe',
+          username: 'johndoe',
+        },
+        date: Math.floor(Date.now() / 1000),
+        text: '/private-test-phrase',
+      },
+    };
+
+    // when - send webhook update
+    const webhookResponse = await request(bootstrap.app.getHttpServer())
+      .post('/notification_channel_setup/telegram/bot_webhook')
+      .set('X-Telegram-Bot-Api-Secret-Token', validTelegramSecret)
+      .send(telegramUpdate);
+
+    // then - webhook should be processed successfully
+    expect(webhookResponse.status).toBe(201);
+
+    // when - fetch chat info using passphrase
+    const chatInfoResponse = await request(bootstrap.app.getHttpServer())
+      .get('/notification_channel_setup/telegram/chat_info')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ passphrase: '/private-test-phrase' });
+
+    // then - should return correct chat info
+    expect(chatInfoResponse.status).toBe(200);
+    expect(chatInfoResponse.body).toEqual({
+      success: true,
+      chatId: '123456789',
+      name: 'John Doe',
+    });
+  });
+
+  it('gets group chat info', async () => {
+    const { token } = await bootstrap.utils.generalUtils.setupAnonymous();
+
+    const groupPassphrase = '/group-test-phrase';
+    const telegramUpdate: TelegramUpdateDto = {
+      update_id: 123457,
+      message: {
+        message_id: 2,
+        from: {
+          id: 987654321,
+          is_bot: false,
+          first_name: 'John',
+          username: 'johndoe',
+        },
+        chat: {
+          id: 987654321,
+          type: 'group',
+          title: 'Dev Team Group',
+        },
+        date: Math.floor(Date.now() / 1000),
+        text: groupPassphrase,
+      },
+    };
+
+    // when - send webhook update for group chat
+    const webhookResponse = await request(bootstrap.app.getHttpServer())
+      .post('/notification_channel_setup/telegram/bot_webhook')
+      .set('X-Telegram-Bot-Api-Secret-Token', validTelegramSecret)
+      .send(telegramUpdate);
+
+    // then - webhook should be processed successfully
+    expect(webhookResponse.status).toBe(201);
+
+    // when - fetch chat info
+    const chatInfoResponse = await request(bootstrap.app.getHttpServer())
+      .get('/notification_channel_setup/telegram/chat_info')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ passphrase: groupPassphrase });
+
+    // then - should return group chat info
+    expect(chatInfoResponse.status).toBe(200);
+    expect(chatInfoResponse.body).toEqual({
+      success: true,
+      chatId: '987654321',
+      name: 'Dev Team Group',
+    });
+  });
+
+  it('rejects webhook update with invalid secret', async () => {
+    const { token } = await bootstrap.utils.generalUtils.setupAnonymous();
+
+    const telegramUpdate: TelegramUpdateDto = {
+      update_id: 123458,
+      message: {
+        message_id: 3,
+        from: {
+          id: 987654321,
+          is_bot: false,
+          first_name: 'John',
+        },
+        chat: {
+          id: 123456789,
+          type: 'private',
+          first_name: 'John',
+        },
+        date: Math.floor(Date.now() / 1000),
+        text: 'invalid-secret-test',
+      },
+    };
+
+    // when - send webhook update with invalid secret
+    await request(bootstrap.app.getHttpServer())
+      .post('/notification_channel_setup/telegram/bot_webhook')
+      .set('X-Telegram-Bot-Api-Secret-Token', 'invalid-secret')
+      .send(telegramUpdate);
+
+    // then - chat info should not be stored
+    const chatInfoResponse = await request(bootstrap.app.getHttpServer())
+      .get('/notification_channel_setup/telegram/chat_info')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ passphrase: 'invalid-secret-test' });
+
+    expect(chatInfoResponse.status).toBe(200);
+    expect(chatInfoResponse.body).toEqual({
+      success: false,
+    });
+  });
+
+  it('rejects webhook update with invalid passphrase', async () => {
+    const { token } = await bootstrap.utils.generalUtils.setupAnonymous();
+
+    const telegramUpdate: TelegramUpdateDto = {
+      update_id: 123459,
+      message: {
+        message_id: 4,
+        from: {
+          id: 987654321,
+          is_bot: false,
+          first_name: 'John',
+        },
+        chat: {
+          id: 123456789,
+          type: 'private',
+          first_name: 'John',
+        },
+        date: Math.floor(Date.now() / 1000),
+        text: 'invalid-passphrase-test', // invalid because it doesn't start with '/'
+      },
+    };
+
+    // when - send webhook update with invalid passphrase
+    await request(bootstrap.app.getHttpServer())
+      .post('/notification_channel_setup/telegram/bot_webhook')
+      .set('X-Telegram-Bot-Api-Secret-Token', validTelegramSecret)
+      .send(telegramUpdate);
+
+    // then - chat info should not be stored
+    const chatInfoResponse = await request(bootstrap.app.getHttpServer())
+      .get('/notification_channel_setup/telegram/chat_info')
+      .set('Authorization', `Bearer ${token}`)
+      .query({ passphrase: 'invalid-passphrase-test' });
+
+    expect(chatInfoResponse.status).toBe(200);
+    expect(chatInfoResponse.body).toEqual({
+      success: false,
+    });
+  });
+});


### PR DESCRIPTION
Outside of this MR I manually configured 3 telegram bots (per each environment) and bound them to newly introduced webhook. Webhooks are secured via randomly generated secrets

Each time someone messages bot or sends message to a chat where bot is participant, we will get updates. We store these updates in redis for 1 minute.

Flow is as follows:
- user messages bot with passphrase randomly generated on frontend. For example `/logdash-happy-capibara-eating-a-banana`,
- we receive webhook update and we save information that passphrase `/logdash-happy-capibara-eating-a-banana` was received in `chatId` for example `abcd123`,
- frontend asks backend what is the `chatId` for passphrase `/logdash-happy-capibara-eating-a-banana`,
- we respond based on previously saved data,
- frontend is now able to create new notification channel and provide `chatId`

![image](https://github.com/user-attachments/assets/e3b24910-797e-4a56-b67e-87e98436f246)

