### PR TITLE
feat: tiered pings

### DIFF
--- a/apps/backend/src/http-monitor/read/http-monitor-read.service.ts
+++ b/apps/backend/src/http-monitor/read/http-monitor-read.service.ts
@@ -58,8 +58,13 @@ export class HttpMonitorReadService {
     return this.httpMonitorModel.countDocuments().lean().exec();
   }
 
-  public async *readAllCursor(): AsyncGenerator<HttpMonitorNormalized> {
-    const cursor = this.httpMonitorModel.find().sort({ createdAt: -1 }).cursor();
+  public async *readManyByProjectIdsCursor(
+    projectIds: string[],
+  ): AsyncGenerator<HttpMonitorNormalized> {
+    const cursor = this.httpMonitorModel
+      .find({ projectId: { $in: projectIds } })
+      .sort({ createdAt: -1 })
+      .cursor();
 
     for await (const entity of cursor) {
       yield HttpMonitorSerializer.normalize(entity);

--- a/apps/backend/src/http-ping/schedule/http-ping-scheduler.module.ts
+++ b/apps/backend/src/http-ping/schedule/http-ping-scheduler.module.ts
@@ -1,7 +1,6 @@
 import { Module } from '@nestjs/common';
 import { HttpMonitorReadModule } from 'src/http-monitor/read/http-monitor-read.module';
 import { getEnvConfig } from 'src/shared/configs/env-configs';
-import { UserReadModule } from 'src/user/read/user-read.module';
 import { ProjectReadModule } from '../../project/read/project-read.module';
 import { HttpPingWriteModule } from '../write/http-ping-write.module';
 import { HttpPingSchedulerDataService } from './http-ping-scheduler.data-service';
@@ -11,7 +10,7 @@ import {
 } from './http-ping-scheduler.service';
 
 @Module({
-  imports: [HttpMonitorReadModule, HttpPingWriteModule, ProjectReadModule, UserReadModule],
+  imports: [HttpMonitorReadModule, HttpPingWriteModule, ProjectReadModule],
   providers: [
     HttpPingSchedulerService,
     HttpPingSchedulerDataService,

--- a/apps/backend/src/http-ping/schedule/http-ping-scheduler.module.ts
+++ b/apps/backend/src/http-ping/schedule/http-ping-scheduler.module.ts
@@ -1,16 +1,17 @@
 import { Module } from '@nestjs/common';
 import { HttpMonitorReadModule } from 'src/http-monitor/read/http-monitor-read.module';
 import { getEnvConfig } from 'src/shared/configs/env-configs';
+import { UserReadModule } from 'src/user/read/user-read.module';
+import { ProjectReadModule } from '../../project/read/project-read.module';
 import { HttpPingWriteModule } from '../write/http-ping-write.module';
+import { HttpPingSchedulerDataService } from './http-ping-scheduler.data-service';
 import {
   HttpPingSchedulerService,
   MAX_CONCURRENT_REQUESTS_TOKEN,
 } from './http-ping-scheduler.service';
-import { HttpPingSchedulerDataService } from './http-ping-scheduler.data-service';
-import { ProjectReadModule } from '../../project/read/project-read.module';
 
 @Module({
-  imports: [HttpMonitorReadModule, HttpPingWriteModule, ProjectReadModule],
+  imports: [HttpMonitorReadModule, HttpPingWriteModule, ProjectReadModule, UserReadModule],
   providers: [
     HttpPingSchedulerService,
     HttpPingSchedulerDataService,

--- a/apps/backend/src/http-ping/schedule/http-ping-scheduler.service.ts
+++ b/apps/backend/src/http-ping/schedule/http-ping-scheduler.service.ts
@@ -3,6 +3,10 @@ import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import axios from 'axios';
 import { HttpMonitorNormalized } from 'src/http-monitor/core/entities/http-monitor.interface';
+import { ProjectReadService } from 'src/project/read/project-read.service';
+import { UserPlanConfigs } from 'src/shared/configs/user-plan-configs';
+import { UserTier } from 'src/user/core/enum/user-tier.enum';
+import { UserReadService } from 'src/user/read/user-read.service';
 import { HttpMonitorReadService } from '../../http-monitor/read/http-monitor-read.service';
 import { AverageRecorder } from '../../shared/logdash/average-metric-recorder.service';
 import { HttpPingEventEmitter } from '../events/http-ping-event.emitter';
@@ -29,31 +33,57 @@ export class HttpPingSchedulerService {
     @Inject(MAX_CONCURRENT_REQUESTS_TOKEN)
     private readonly maxConcurrentRequests: number,
     private readonly httpPingSchedulerDataService: HttpPingSchedulerDataService,
+    private readonly userReadService: UserReadService,
+    private readonly projectReadService: ProjectReadService,
   ) {}
 
   @Cron(CronExpression.EVERY_MINUTE)
-  private async triggerPingAllMonitors(): Promise<void> {
+  private async triggerPingMonitors1m(): Promise<void> {
     if (process.env.NODE_ENV === 'test') {
       return;
     }
 
-    await this.tryPingAllMonitors();
+    const tiers = this.getTiersWithFrequency(CronExpression.EVERY_MINUTE);
+    await this.tryPingMonitors(tiers);
   }
 
-  public async tryPingAllMonitors(): Promise<void> {
+  @Cron(CronExpression.EVERY_5_MINUTES)
+  private async triggerPingMonitors5m(): Promise<void> {
+    if (process.env.NODE_ENV === 'test') {
+      return;
+    }
+
+    const tiers = this.getTiersWithFrequency(CronExpression.EVERY_5_MINUTES);
+    await this.tryPingMonitors(tiers);
+  }
+
+  private getTiersWithFrequency(frequency: CronExpression): UserTier[] {
+    return Object.entries(UserPlanConfigs)
+      .filter(([_, value]) => value.pings.frequency === frequency)
+      .map(([key]) => key as keyof typeof UserPlanConfigs);
+  }
+
+  public async tryPingMonitors(userTiers: UserTier[]): Promise<void> {
     try {
-      await this.pingAllMonitors();
+      await this.pingMonitors(userTiers);
     } catch (error) {
       this.logger.error('Error processing HTTP pings:', { errorMessage: error.message });
     }
   }
 
-  private async pingAllMonitors(): Promise<void> {
+  private async pingMonitors(userTiers: UserTier[]): Promise<void> {
     const startTime = Date.now();
     const queue: QueueItem[] = [];
     const results: CreateHttpPingDto[] = [];
 
-    for await (const monitor of this.httpMonitorReadService.readAllCursor()) {
+    const usersIds = (await this.userReadService.readByTiers(userTiers)).map((u) => u.id);
+    const projectsIds = (await this.projectReadService.readManyByCreatorsIds(usersIds)).map(
+      (p) => p.id,
+    );
+
+    for await (const monitor of this.httpMonitorReadService.readManyByProjectIdsCursor(
+      projectsIds,
+    )) {
       if (queue.length >= this.maxConcurrentRequests) {
         const completedItem = await Promise.race(
           queue.map(async (item) => {

--- a/apps/backend/src/project/read/project-read.service.ts
+++ b/apps/backend/src/project/read/project-read.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model, Types } from 'mongoose';
 import { ProjectEntity } from '../core/entities/project.entity';
@@ -57,6 +57,12 @@ export class ProjectReadService {
 
   public async readByCreatorId(creatorId: string): Promise<ProjectNormalized[]> {
     const projects = await this.model.find({ creatorId });
+
+    return projects.map((project) => ProjectSerializer.normalize(project));
+  }
+
+  public async readManyByCreatorsIds(creatorIds: string[]): Promise<ProjectNormalized[]> {
+    const projects = await this.model.find({ creatorId: { $in: creatorIds } });
 
     return projects.map((project) => ProjectSerializer.normalize(project));
   }

--- a/apps/backend/src/project/read/project-read.service.ts
+++ b/apps/backend/src/project/read/project-read.service.ts
@@ -61,8 +61,8 @@ export class ProjectReadService {
     return projects.map((project) => ProjectSerializer.normalize(project));
   }
 
-  public async readManyByCreatorsIds(creatorIds: string[]): Promise<ProjectNormalized[]> {
-    const projects = await this.model.find({ creatorId: { $in: creatorIds } });
+  public async readManyByTiers(tiers: ProjectTier[]): Promise<ProjectNormalized[]> {
+    const projects = await this.model.find({ tier: { $in: tiers } });
 
     return projects.map((project) => ProjectSerializer.normalize(project));
   }

--- a/apps/backend/src/shared/configs/user-plan-configs.ts
+++ b/apps/backend/src/shared/configs/user-plan-configs.ts
@@ -1,5 +1,6 @@
-import { UserTier } from '../../user/core/enum/user-tier.enum';
+import { CronExpression } from '@nestjs/schedule';
 import { NotificationChannelType } from '../../notification-channel/core/enums/notification-target.enum';
+import { UserTier } from '../../user/core/enum/user-tier.enum';
 
 interface UserPlanConfig {
   projects: {
@@ -10,6 +11,9 @@ interface UserPlanConfig {
   };
   notificationChannels: {
     allowedTypes: NotificationChannelType[];
+  };
+  pings: {
+    frequency: CronExpression;
   };
 }
 
@@ -31,6 +35,9 @@ export const UserPlanConfigs: UserPlanConfigs = {
     notificationChannels: {
       allowedTypes: [NotificationChannelType.Telegram, NotificationChannelType.Webhook],
     },
+    pings: {
+      frequency: CronExpression.EVERY_5_MINUTES,
+    },
   },
   [UserTier.Contributor]: {
     projects: {
@@ -41,6 +48,9 @@ export const UserPlanConfigs: UserPlanConfigs = {
     },
     notificationChannels: {
       allowedTypes: [NotificationChannelType.Telegram, NotificationChannelType.Webhook],
+    },
+    pings: {
+      frequency: CronExpression.EVERY_5_MINUTES,
     },
   },
   [UserTier.EarlyBird]: {
@@ -53,6 +63,9 @@ export const UserPlanConfigs: UserPlanConfigs = {
     notificationChannels: {
       allowedTypes: [NotificationChannelType.Telegram, NotificationChannelType.Webhook],
     },
+    pings: {
+      frequency: CronExpression.EVERY_MINUTE,
+    },
   },
   [UserTier.Admin]: {
     projects: {
@@ -63,6 +76,9 @@ export const UserPlanConfigs: UserPlanConfigs = {
     },
     notificationChannels: {
       allowedTypes: [NotificationChannelType.Telegram, NotificationChannelType.Webhook],
+    },
+    pings: {
+      frequency: CronExpression.EVERY_MINUTE,
     },
   },
 };

--- a/apps/backend/src/user/read/user-read.service.ts
+++ b/apps/backend/src/user/read/user-read.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { UserNormalized } from '../core/entities/user.interface';
 import { InjectModel } from '@nestjs/mongoose';
-import { UserEntity } from '../core/entities/user.entity';
 import { Model } from 'mongoose';
+import { UserEntity } from '../core/entities/user.entity';
+import { UserNormalized } from '../core/entities/user.interface';
 import { UserSerializer } from '../core/entities/user.serializer';
 import { AccountClaimStatus } from '../core/enum/account-claim-status.enum';
+import { UserTier } from '../core/enum/user-tier.enum';
 
 @Injectable()
 export class UserReadService {
@@ -44,5 +45,14 @@ export class UserReadService {
     for await (const user of cursor) {
       yield user._id.toString();
     }
+  }
+
+  public async readByTiers(tiers: UserTier[]): Promise<UserNormalized[]> {
+    const users = await this.userModel
+      .find({ tier: { $in: tiers } })
+      .lean<UserEntity[]>()
+      .exec();
+
+    return users.map((user) => UserSerializer.normalize(user));
   }
 }

--- a/apps/backend/src/user/read/user-read.service.ts
+++ b/apps/backend/src/user/read/user-read.service.ts
@@ -5,7 +5,6 @@ import { UserEntity } from '../core/entities/user.entity';
 import { UserNormalized } from '../core/entities/user.interface';
 import { UserSerializer } from '../core/entities/user.serializer';
 import { AccountClaimStatus } from '../core/enum/account-claim-status.enum';
-import { UserTier } from '../core/enum/user-tier.enum';
 
 @Injectable()
 export class UserReadService {
@@ -45,14 +44,5 @@ export class UserReadService {
     for await (const user of cursor) {
       yield user._id.toString();
     }
-  }
-
-  public async readByTiers(tiers: UserTier[]): Promise<UserNormalized[]> {
-    const users = await this.userModel
-      .find({ tier: { $in: tiers } })
-      .lean<UserEntity[]>()
-      .exec();
-
-    return users.map((user) => UserSerializer.normalize(user));
   }
 }

--- a/apps/backend/test/http-monitors/full-process.spec.ts
+++ b/apps/backend/test/http-monitors/full-process.spec.ts
@@ -1,8 +1,9 @@
-import { createTestApp } from '../utils/bootstrap';
+import * as nock from 'nock';
 import { HttpPingSchedulerService } from '../../src/http-ping/schedule/http-ping-scheduler.service';
 import { TelegramOptions } from '../../src/notification-channel/core/types/telegram-options.type';
+import { UserTier } from '../../src/user/core/enum/user-tier.enum';
+import { createTestApp } from '../utils/bootstrap';
 import { sleep } from '../utils/sleep';
-import * as nock from 'nock';
 
 describe('Http monitor full process', () => {
   let bootstrap: Awaited<ReturnType<typeof createTestApp>>;
@@ -51,15 +52,15 @@ describe('Http monitor full process', () => {
     // at first the status is unknown
     // unknown -> up
     nock('https://chess.com').get('/').reply(200, 'ok');
-    await service.tryPingAllMonitors();
+    await service.tryPingMonitors([UserTier.Free]);
 
     // up -> down
     nock('https://chess.com').get('/').reply(500, { error: 'some funny error' });
-    await service.tryPingAllMonitors();
+    await service.tryPingMonitors([UserTier.Free]);
 
     // down -> up
     nock('https://chess.com').get('/').reply(200, 'ok');
-    await service.tryPingAllMonitors();
+    await service.tryPingMonitors([UserTier.Free]);
 
     await sleep(1000);
 

--- a/apps/backend/test/http-ping/sse.spec.ts
+++ b/apps/backend/test/http-ping/sse.spec.ts
@@ -4,6 +4,7 @@ import { HttpPingCoreController } from '../../src/http-ping/core/http-ping-core.
 import { HttpPingSchedulerService } from '../../src/http-ping/schedule/http-ping-scheduler.service';
 import { createTestApp } from '../utils/bootstrap';
 import { URL_STUB } from '../utils/http-monitor-utils';
+import { UserTier } from '../../src/user/core/enum/user-tier.enum';
 
 describe('Http Ping (SSE)', () => {
   let controller: HttpPingCoreController;
@@ -44,7 +45,7 @@ describe('Http Ping (SSE)', () => {
       const stream = await controller.streamHttpMonitorPings(setupA.cluster.id);
       const resultsPromise = firstValueFrom(stream.pipe(take(1)));
 
-      await schedulerService.tryPingAllMonitors();
+      await schedulerService.tryPingMonitors([UserTier.Free]);
 
       // then
       const results = await resultsPromise;
@@ -77,9 +78,9 @@ describe('Http Ping (SSE)', () => {
       const stream = await controller.streamHttpMonitorPings(setupA.cluster.id);
       const resultsPromise = firstValueFrom(stream.pipe(take(2), toArray()));
       nock(URL_STUB).get('/').times(2).delay(10).reply(200);
-      await schedulerService.tryPingAllMonitors();
+      await schedulerService.tryPingMonitors([UserTier.Free]);
       nock(URL_STUB).get('/').times(2).delay(10).reply(404);
-      await schedulerService.tryPingAllMonitors();
+      await schedulerService.tryPingMonitors([UserTier.Free]);
 
       // then
       const results = await resultsPromise;

--- a/apps/backend/test/http-ping/writes.spec.ts
+++ b/apps/backend/test/http-ping/writes.spec.ts
@@ -1,5 +1,6 @@
 import * as nock from 'nock';
 import { HttpPingSchedulerService } from '../../src/http-ping/schedule/http-ping-scheduler.service';
+import { UserTier } from '../../src/user/core/enum/user-tier.enum';
 import { createTestApp } from '../utils/bootstrap';
 import { URL_STUB } from '../utils/http-monitor-utils';
 
@@ -23,8 +24,12 @@ describe('Http Ping (writes)', () => {
 
   it('stores pings for multiple monitors', async () => {
     // given
-    const setupA = await bootstrap.utils.generalUtils.setupAnonymous();
-    const setupB = await bootstrap.utils.generalUtils.setupAnonymous();
+    const setupA = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
+    const setupB = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
     const monitorA = await bootstrap.utils.httpMonitorsUtils.createHttpMonitor({
       token: setupA.token,
       projectId: setupA.project.id,
@@ -35,8 +40,8 @@ describe('Http Ping (writes)', () => {
     });
 
     // when
-    await schedulerService.tryPingAllMonitors();
-    await schedulerService.tryPingAllMonitors();
+    await schedulerService.tryPingMonitors([UserTier.EarlyBird]);
+    await schedulerService.tryPingMonitors([UserTier.EarlyBird]);
 
     // then
     const pingsA = await bootstrap.utils.httpPingUtils.getMonitorPings({
@@ -53,7 +58,9 @@ describe('Http Ping (writes)', () => {
 
   it('handles pings for a large number of monitors', async () => {
     // given
-    const setup = await bootstrap.utils.generalUtils.setupAnonymous();
+    const setup = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
     for (let i = 0; i < 1000; i++) {
       await bootstrap.utils.httpMonitorsUtils.storeHttpMonitor({
         token: setup.token,
@@ -62,7 +69,41 @@ describe('Http Ping (writes)', () => {
     }
 
     // when
-    await schedulerService.tryPingAllMonitors();
+    await schedulerService.tryPingMonitors([UserTier.EarlyBird]);
+
+    // then
+    const allPings = await bootstrap.utils.httpPingUtils.getAllPings();
+    expect(allPings.length).toBe(1000);
+  }, 30000);
+
+  it('handles pings for large number of users, projects and monitors', async () => {
+    // given
+    const setups = await Promise.all(
+      Array.from({ length: 1000 }, (_, i) => {
+        return bootstrap.utils.userUtils.createDefaultUser({
+          tier: UserTier.EarlyBird,
+        });
+      }),
+    );
+
+    const projects = await Promise.all(
+      setups.map((setup) =>
+        bootstrap.utils.projectUtils.createDefaultProject({
+          userId: setup.id,
+        }),
+      ),
+    );
+    
+    await Promise.all(
+      projects.map((project) =>
+        bootstrap.utils.httpMonitorsUtils.storeHttpMonitor({
+          projectId: project.id,
+        }),
+      ),
+    );
+
+    // when
+    await schedulerService.tryPingMonitors([UserTier.EarlyBird]);
 
     // then
     const allPings = await bootstrap.utils.httpPingUtils.getAllPings();
@@ -71,7 +112,9 @@ describe('Http Ping (writes)', () => {
 
   it('stores pings with failed status code', async () => {
     // given
-    const { token, project } = await bootstrap.utils.generalUtils.setupAnonymous();
+    const { token, project } = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
     const anotherUrl = 'https://another-url.com';
     const monitor = await bootstrap.utils.httpMonitorsUtils.createHttpMonitor({
       token,
@@ -81,7 +124,7 @@ describe('Http Ping (writes)', () => {
     nock(anotherUrl).persist().get('/').delay(10).reply(403);
 
     // when
-    await schedulerService.tryPingAllMonitors();
+    await schedulerService.tryPingMonitors([UserTier.EarlyBird]);
 
     // then
     const pings = await bootstrap.utils.httpPingUtils.getMonitorPings({
@@ -93,5 +136,38 @@ describe('Http Ping (writes)', () => {
       responseTimeMs: expect.any(Number),
       message: 'Forbidden',
     });
+  });
+
+  it('does not ping monitors for users with other tier', async () => {
+    // given
+    const setupA = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.Free,
+    });
+    const setupB = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
+    const monitorA = await bootstrap.utils.httpMonitorsUtils.createHttpMonitor({
+      token: setupA.token,
+      projectId: setupA.project.id,
+    });
+    const monitorB = await bootstrap.utils.httpMonitorsUtils.createHttpMonitor({
+      token: setupB.token,
+      projectId: setupB.project.id,
+    });
+
+    // when
+    await schedulerService.tryPingMonitors([UserTier.Free]);
+
+    // then
+    const pingsA = await bootstrap.utils.httpPingUtils.getMonitorPings({
+      httpMonitorId: monitorA.id,
+    });
+    const pingsB = await bootstrap.utils.httpPingUtils.getMonitorPings({
+      httpMonitorId: monitorB.id,
+    });
+    const allPings = await bootstrap.utils.httpPingUtils.getAllPings();
+    expect(pingsA.length).toBe(1);
+    expect(pingsB.length).toBe(0);
+    expect(allPings.length).toBe(1);
   });
 });

--- a/apps/backend/test/http-ping/writes.spec.ts
+++ b/apps/backend/test/http-ping/writes.spec.ts
@@ -1,5 +1,6 @@
 import * as nock from 'nock';
 import { HttpPingSchedulerService } from '../../src/http-ping/schedule/http-ping-scheduler.service';
+import { ProjectTier } from '../../src/project/core/enums/project-tier.enum';
 import { UserTier } from '../../src/user/core/enum/user-tier.enum';
 import { createTestApp } from '../utils/bootstrap';
 import { URL_STUB } from '../utils/http-monitor-utils';
@@ -76,24 +77,21 @@ describe('Http Ping (writes)', () => {
     expect(allPings.length).toBe(1000);
   }, 30000);
 
-  it('handles pings for large number of users, projects and monitors', async () => {
+  it('handles pings for large number of projects and monitors', async () => {
     // given
-    const setups = await Promise.all(
-      Array.from({ length: 1000 }, (_, i) => {
-        return bootstrap.utils.userUtils.createDefaultUser({
-          tier: UserTier.EarlyBird,
-        });
-      }),
-    );
+    const setup = await bootstrap.utils.generalUtils.setupAnonymous({
+      userTier: UserTier.EarlyBird,
+    });
 
     const projects = await Promise.all(
-      setups.map((setup) =>
+      Array.from({ length: 1000 }, () =>
         bootstrap.utils.projectUtils.createDefaultProject({
-          userId: setup.id,
+          userId: setup.user.id,
+          tier: ProjectTier.EarlyBird,
         }),
       ),
     );
-    
+
     await Promise.all(
       projects.map((project) =>
         bootstrap.utils.httpMonitorsUtils.storeHttpMonitor({

--- a/apps/backend/test/utils/bootstrap.ts
+++ b/apps/backend/test/utils/bootstrap.ts
@@ -64,6 +64,7 @@ import { SubscriptionEntity } from '../../src/subscription/core/entities/subscri
 import { SubscriptionCoreModule } from '../../src/subscription/core/subscription-core.module';
 import { AuditLogUtils } from './audit-log-utils';
 import { AuditLogCreationModule } from '../../src/audit-log/creation/audit-log-creation.module';
+import { UserUtils } from './user.utils';
 
 export async function createTestApp() {
   const module: TestingModule = await Test.createTestingModule({
@@ -220,6 +221,7 @@ export async function createTestApp() {
       publicDashboardUtils: new PublicDashboardUtils(app),
       auditLogUtils: new AuditLogUtils(app),
       clusterInviteUtils: new ClusterInviteUtils(app),
+      userUtils: new UserUtils(app),
     },
     methods: {
       clearDatabase,

--- a/apps/backend/test/utils/http-monitor-utils.ts
+++ b/apps/backend/test/utils/http-monitor-utils.ts
@@ -32,7 +32,7 @@ export class HttpMonitorUtils {
   }
 
   public async storeHttpMonitor(
-    dto: Partial<CreateHttpMonitorBody> & { token: string; projectId: string },
+    dto: Partial<CreateHttpMonitorBody> & { token?: string; projectId: string },
   ): Promise<HttpMonitorNormalized> {
     this.tryFillDto(dto);
     const monitor = await this.httpMonitorModel.create(dto);

--- a/apps/backend/test/utils/user.utils.ts
+++ b/apps/backend/test/utils/user.utils.ts
@@ -1,0 +1,46 @@
+import { INestApplication } from '@nestjs/common';
+
+import { getModelToken } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { UserEntity } from '../../src/user/core/entities/user.entity';
+import { UserNormalized } from '../../src/user/core/entities/user.interface';
+import { UserSerializer } from '../../src/user/core/entities/user.serializer';
+import { AccountClaimStatus } from '../../src/user/core/enum/account-claim-status.enum';
+import { AuthMethod } from '../../src/user/core/enum/auth-method.enum';
+import { UserTier } from '../../src/user/core/enum/user-tier.enum';
+
+export class UserUtils {
+  private userModel: Model<UserEntity>;
+
+  constructor(private readonly app: INestApplication<any>) {
+    this.userModel = this.app.get(getModelToken(UserEntity.name));
+  }
+
+  public async getUser(): Promise<UserNormalized | null> {
+    const user = await this.userModel.findOne();
+    return user ? UserSerializer.normalize(user) : null;
+  }
+
+  public async createDefaultUser(params?: {
+    email?: string;
+    authMethod?: AuthMethod;
+    accountClaimStatus?: AccountClaimStatus;
+    tier?: UserTier;
+    stripeCustomerId?: string;
+    avatarUrl?: string;
+    marketingConsent?: boolean;
+  }): Promise<UserNormalized> {
+    const user = await this.userModel.create({
+      email: params?.email || `test-user-${Math.random()}@example.com`,
+      authMethod: params?.authMethod || AuthMethod.Traditional,
+      accountClaimStatus: params?.accountClaimStatus || AccountClaimStatus.Claimed,
+      lastActivityDate: new Date(),
+      tier: params?.tier || UserTier.Free,
+      stripeCustomerId: params?.stripeCustomerId,
+      avatarUrl: params?.avatarUrl,
+      marketingConsent: params?.marketingConsent || false,
+    });
+
+    return UserSerializer.normalize(user);
+  }
+}


### PR DESCRIPTION
## Previous solution
Single cron for pinging all monitors every minute

## New solution
2 separate crons pinging tiered monitors every 1 & 5 minutes.

- every 1 min: Early Bird & Admins
- every 5 min: Free & Contributor
- can be changed later on in `UserPlanConfigs`

## Implementation details
- find `users` of given _tiers_ in Mongo collection
- find `projects` of given _creators_ (_users_) in Mongo collection
- cursor-find `http-monitors` by _projects ids_ in Clickhouse table