### PR TITLE
chore: sync VITE_* env vars from Vercel to wrangler.jsonc

### DIFF
--- a/apps/frontend/wrangler.jsonc
+++ b/apps/frontend/wrangler.jsonc
@@ -11,4 +11,13 @@
   "observability": {
     "enabled": true,
   },
+  "vars": {
+    "VITE_POSTHOG_KEY": "phc_z0enAmNPcCT1IkHnNU7TVo4DcrC1YzPgCK42UYib0kJ",
+    "VITE_POSTHOG_HOST": "https://eu.posthog.com",
+    "VITE_POSTHOG_PROXY": "/ingest/",
+    "VITE_GITHUB_CLIENT_ID": "Ov23liSHxH2asHmTy1M4",
+    "VITE_GOOGLE_CLIENT_ID": "814987938118-s1gf11r5trjsm6k6d08fkkosa48lrpbo.apps.googleusercontent.com",
+    "VITE_API_BASE_URL": "https://api.logdash.io",
+    "VITE_STAGE": "live",
+  },
 }


### PR DESCRIPTION
## Summary
- Adds the seven `VITE_*` build-time env vars (PostHog, GitHub/Google client IDs, API base URL, stage) to `apps/frontend/wrangler.jsonc` so Cloudflare Workers Builds injects them into the Vite build the same way Vercel previously did.

## Test plan
- [x] `wrangler deploy` — bindings show up on the deployed Worker
- [ ] Confirm Cloudflare Workers Builds picks up the `vars` for the Vite build on the next deploy